### PR TITLE
Add easy start script and setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,6 @@ myenv/
 Khoa_hoc_mau/
 *.srt
 *.txt
+!requirements.txt
 *.json
 *.csv

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# VoiceSub-Translator
+
+Công cụ giúp tự động xử lý và dịch phụ đề cho video.
+
+## Cài đặt nhanh
+
+1. Cài Python 3.10+ và [ffmpeg](https://ffmpeg.org/).
+2. Tải mã nguồn và mở thư mục dự án:
+
+   ```bash
+   git clone <duong-dan-repo>
+   cd VoiceSub-Translator
+   python -m venv .venv
+   source .venv/bin/activate   # Windows: .venv\Scripts\activate
+   pip install -r requirements.txt
+   cp .env.example .env         # sửa lại nếu cần API key
+   python run.py
+   ```
+
+3. Giao diện sẽ hiển thị, chọn thư mục và bắt đầu xử lý phụ đề.
+
+## Kiểm tra (tùy chọn)
+
+Sau khi cài đặt, có thể chạy bộ kiểm thử:
+
+```bash
+pytest
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+customtkinter
+python-dotenv
+faster-whisper
+whisper
+torch==2.4.0
+psutil
+google-generativeai
+requests
+ffmpeg-python
+pillow
+pytest

--- a/run.py
+++ b/run.py
@@ -1,0 +1,4 @@
+from src.gui.modern_app import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run.py` to launch the modern GUI
- provide `requirements.txt` and update `.gitignore` to track it
- document simple installation and usage steps in README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'backoff')*

------
https://chatgpt.com/codex/tasks/task_e_689b49ed5b648320bd21129de11b0e7b